### PR TITLE
Sprint-13 add-most-populars выполнено задание, протестировано в postman

### DIFF
--- a/src/main/java/ru/yandex/practicum/filmorate/controller/FilmController.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/controller/FilmController.java
@@ -53,10 +53,13 @@ public class FilmController {
         return service.deleteLike(id, userId);
     }
 
+    // пример запроса будет выглядить так GET /films/popular?count={limit}&genreId={genreId}&year={year}
     @GetMapping("/popular")
     public Collection<Film> getPopular(
-            @RequestParam(defaultValue = "10", required = false) Long count) {
-        return service.getPopular(count);
+            @RequestParam(defaultValue = "10", required = false) Long count,
+            @RequestParam(defaultValue = "0", required = false) Long genreId,
+            @RequestParam(defaultValue = "0", required = false) int year) {
+        return service.getPopular(count, genreId, year);
     }
 
 }

--- a/src/main/java/ru/yandex/practicum/filmorate/service/FilmService.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/FilmService.java
@@ -44,8 +44,8 @@ public class FilmService {
         return storage.deleteLike(id, userId);
     }
 
-    public Collection<Film> getPopular(Long count) {
-        return storage.getPopular(count);
+    public Collection<Film> getPopular(Long count, Long genreId, int year) {
+        return storage.getPopular(count, genreId, year);
     }
 
     private void validate(Film film) {

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/FilmDbStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/FilmDbStorage.java
@@ -73,10 +73,73 @@ public class FilmDbStorage extends BaseDbStorage<Film> implements FilmStorage {
             COUNT(l."film_id") AS count
             FROM "films" AS f
             LEFT JOIN "likes" AS l ON l."film_id" = f."film_id"
-            LEFT JOIN "mpas" AS r ON  f."mpa_id" = r."mpa_id"
+            LEFT JOIN "mpas" AS r ON f."mpa_id" = r."mpa_id"
+            LEFT JOIN "films_genre" AS fg ON fg."film_id" = f."film_id"
+            LEFT JOIN "genres" AS g ON g."genre_id" = fg."genre_id"
             GROUP BY "film_id"
             ORDER BY count DESC
             LIMIT ?;
+            """;
+
+    private static final String FILMS_GET_POPULAR_QUERY_WITH_GENRE = """
+            SELECT
+                        f."film_id" AS "film_id",
+                        f."name" AS "name",
+                        f."description" AS "description",
+                        f."release_date" AS "release_date",
+                        f."duration" AS "duration",
+                        r."mpa_id" AS "mpa_id",
+                        r."mpa" AS "mpa",
+                        COUNT(l."film_id") AS count
+                    FROM "films" AS f
+                    LEFT JOIN "likes" AS l ON l."film_id" = f."film_id"
+                    LEFT JOIN "mpas" AS r ON f."mpa_id" = r."mpa_id"
+                    LEFT JOIN "films_genre" AS fg ON fg."film_id" = f."film_id"
+                    LEFT JOIN "genres" AS g ON g."genre_id" = fg."genre_id"
+                    WHERE fg."genre_id" = ?
+                    GROUP BY "film_id"
+                    ORDER BY count DESC
+                    LIMIT ?;
+            """;
+    private static final String FILMS_GET_POPULAR_QUERY_WITH_YEAR = """
+            SELECT
+                        f."film_id" AS "film_id",
+                        f."name" AS "name",
+                        f."description" AS "description",
+                        f."release_date" AS "release_date",
+                        f."duration" AS "duration",
+                        r."mpa_id" AS "mpa_id",
+                        r."mpa" AS "mpa",
+                        COUNT(l."film_id") AS count
+                    FROM "films" AS f
+                    LEFT JOIN "likes" AS l ON l."film_id" = f."film_id"
+                    LEFT JOIN "mpas" AS r ON f."mpa_id" = r."mpa_id"
+                    LEFT JOIN "films_genre" AS fg ON fg."film_id" = f."film_id"
+                    LEFT JOIN "genres" AS g ON g."genre_id" = fg."genre_id"
+                    WHERE EXTRACT(YEAR FROM f."release_date") = ?
+                    GROUP BY "film_id"
+                    ORDER BY count DESC
+                    LIMIT ?;
+            """;
+    private static final String FILMS_GET_POPULAR_QUERY_WITH_YEAR_AND_GENRE = """
+            SELECT
+                        f."film_id" AS "film_id",
+                        f."name" AS "name",
+                        f."description" AS "description",
+                        f."release_date" AS "release_date",
+                        f."duration" AS "duration",
+                        r."mpa_id" AS "mpa_id",
+                        r."mpa" AS "mpa",
+                        COUNT(l."film_id") AS count
+                    FROM "films" AS f
+                    LEFT JOIN "likes" AS l ON l."film_id" = f."film_id"
+                    LEFT JOIN "mpas" AS r ON f."mpa_id" = r."mpa_id"
+                    LEFT JOIN "films_genre" AS fg ON fg."film_id" = f."film_id"
+                    LEFT JOIN "genres" AS g ON g."genre_id" = fg."genre_id"
+                    WHERE EXTRACT(YEAR FROM f."release_date") = ? AND fg."genre_id" = ?
+                    GROUP BY "film_id"
+                    ORDER BY count DESC
+                    LIMIT ?;
             """;
     private static final String FILMS_DELETE_FILMS_GENRE_QUERY = """
             DELETE FROM "films_genre"
@@ -227,13 +290,31 @@ public class FilmDbStorage extends BaseDbStorage<Film> implements FilmStorage {
     }
 
     @Override
-    public Collection<Film> getPopular(Long count) {
+    public Collection<Film> getPopular(Long count, Long genreId, int year) {
         if (count <= 0) throw new ValidationException("Параметр count должен быть больше 0");
         log.info("Получение списка {} популярных фильмов", count);
+        //если ищем по count и year
+        if (genreId == 0L && year >= 1) {
+            return findMany(
+                    FILMS_GET_POPULAR_QUERY_WITH_YEAR,
+                    year, count);
+        }
+        //если ищем по count и genre
+        if (genreId >= 1L && year == 0) {
+            return findMany(
+                    FILMS_GET_POPULAR_QUERY_WITH_GENRE,
+                    genreId, count);
+        }
+        //если ищем по count, genre и year
+        if (genreId >= 1L && year >= 1) {
+            return findMany(
+                    FILMS_GET_POPULAR_QUERY_WITH_YEAR_AND_GENRE,
+                    year, genreId, count);
+        }
+        //только count
         return findMany(
-                FILMS_GET_POPULAR_QUERY,
-                count
-        );
+                    FILMS_GET_POPULAR_QUERY,
+                    count);
     }
 
     public boolean checkFilmExists(Long id) {

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/FilmStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/FilmStorage.java
@@ -19,5 +19,5 @@ public interface FilmStorage {
 
     Film deleteLike(Long id, Long userId);
 
-    Collection<Film> getPopular(Long count);
+    Collection<Film> getPopular(Long count, Long genreId, int year);
 }

--- a/src/test/java/ru/yandex/practicum/filmorate/storage/FilmDbStorageTest.java
+++ b/src/test/java/ru/yandex/practicum/filmorate/storage/FilmDbStorageTest.java
@@ -317,7 +317,7 @@ class FilmDbStorageTest {
         filmDbStorage.addLike(film3Id, user2Id);
 
 
-        ArrayList<Film> responseEntity = new ArrayList<>(filmDbStorage.getPopular(10L));
+        ArrayList<Film> responseEntity = new ArrayList<>(filmDbStorage.getPopular(10L, 0L, 0));
         assertNotNull(responseEntity);
         assertEquals(3, responseEntity.size());
         assertEquals(film2Id, responseEntity.get(0).getId());
@@ -349,7 +349,7 @@ class FilmDbStorageTest {
         filmDbStorage.addLike(film3Id, user2Id);
 
 
-        ArrayList<Film> responseEntity = new ArrayList<>(filmDbStorage.getPopular(1L));
+        ArrayList<Film> responseEntity = new ArrayList<>(filmDbStorage.getPopular(1L,0L, 0));
         assertNotNull(responseEntity);
         assertEquals(1, responseEntity.size());
         assertEquals(film2Id, responseEntity.get(0).getId());


### PR DESCRIPTION
🎦 Ветка для реализации задачи должна называться add-most-populars.

Описание задачи
Добавить возможность выводить топ-N фильмов по количеству лайков.

Фильтрация должна быть по двум параметрам.

По жанру.
За указанный год.
API
GET /films/popular?count={limit}&genreId={genreId}&year={year}

Возвращает список самых популярных фильмов указанного жанра за нужный год.